### PR TITLE
Upgrade to Elixir 1.4

### DIFF
--- a/lib/mix_docker.ex
+++ b/lib/mix_docker.ex
@@ -73,7 +73,7 @@ defmodule MixDocker do
   end
 
   defp image(tag) do
-    image_name <> ":" <> to_string(image_tag(tag))
+    image_name() <> ":" <> to_string(image_tag(tag))
   end
 
   defp image_name do
@@ -82,8 +82,8 @@ defmodule MixDocker do
 
   defp image_tag(:version) do
     version = Mix.Project.get.project[:version]
-    count   = git_commit_count
-    sha     = git_head_sha
+    count   = git_commit_count()
+    sha     = git_head_sha()
 
     "#{version}.#{count}-#{sha}"
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,14 +4,14 @@ defmodule MixDocker.Mixfile do
   def project do
     [
       app: :mix_docker,
-      version: "0.3.1",
-      elixir: "~> 1.3",
+      version: "0.4.0",
+      elixir: ">= 1.3.0",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
-      deps: deps,
+      deps: deps(),
 
-      description: description,
-      package: package,
+      description: description(),
+      package: package(),
 
       source_url: "https://github.com/recruitee/mix_docker",
       docs: [main: "readme", extras: ["README.md"]]

--- a/priv/Dockerfile.build
+++ b/priv/Dockerfile.build
@@ -1,14 +1,12 @@
-FROM bitwalker/alpine-erlang:6.1
+# Using alpine-elixir instead of alpine-erlang here
+# because Elixir 1.4 is not yet available in Alpine
+# community packages.
+FROM bitwalker/alpine-elixir
 
 ENV HOME=/opt/app/ TERM=xterm
 
-# Install Elixir and basic build dependencies
-RUN \
-    echo "@edge http://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
-    apk update && \
-    apk --no-cache --update add \
-      git make g++ \
-      elixir@edge && \
+RUN apk update && \
+    apk --no-cache --update add git make g++ && \
     rm -rf /var/cache/apk/*
 
 # Install Hex+Rebar

--- a/priv/Dockerfile.release
+++ b/priv/Dockerfile.release
@@ -1,4 +1,7 @@
-FROM bitwalker/alpine-erlang:6.1
+# No need to have Elixir language installed in the release image,
+# but we use the elixir image as base anyway - to make sure build image
+# and release image use the same version of Erlang.
+FROM bitwalker/alpine-elixir
 
 RUN apk update && \
     apk --no-cache --update add libgcc libstdc++ && \

--- a/priv/dockerignore
+++ b/priv/dockerignore
@@ -7,3 +7,4 @@ test
 tmp
 erl_crash.dump
 *.ez
+node_modules


### PR DESCRIPTION
Thank you for this great and simple tool!

My app runs on Elixir 1.4, so I decided to upgrade `mix_docker` to support it, which wasn't as simple as I thought. I know I could've just used `mix docker.customize`, but I hope this change would save some time to someone not familiar with it.

I tested the changes on a dummy Phoenix app, by referencing this package locally:

```elixir
defp deps do
  # ...,
  {:mix_docker, path: "../github/mix_docker", only: :dev}
end
```

**Changes:**
- Bump package version to 0.4.0 (minor) due to breaking changes.
- Add node_modules to default dockerignore.
- Update Dockerfile.build and Dockerfile.release to use
  alpine-elixir as base.
- Fix Elixir 1.4 warnings.
