### PR TITLE
Update dockerfiles

### DIFF
--- a/priv/Dockerfile.build
+++ b/priv/Dockerfile.build
@@ -1,28 +1,14 @@
-FROM bitwalker/alpine-erlang:6.1
-
-ENV HOME=/opt/app/ TERM=xterm
-
-# Install Elixir and basic build dependencies
-RUN \
-    echo "@edge http://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
-    apk update && \
-    apk --no-cache --update add \
-      git make g++ \
-      elixir@edge && \
-    rm -rf /var/cache/apk/*
-
-# Install Hex+Rebar
-RUN mix local.hex --force && \
-    mix local.rebar --force
-
-WORKDIR /opt/app
+FROM aeons/elixir-gcc:1.4.1
 
 ENV MIX_ENV=prod
 
-# Cache elixir deps
+WORKDIR /opt/app
+
 COPY mix.exs mix.lock ./
+
 RUN mix do deps.get, deps.compile
 
 COPY . .
 
 RUN mix release --env=prod --verbose
+

--- a/priv/Dockerfile.release
+++ b/priv/Dockerfile.release
@@ -2,9 +2,15 @@ FROM alpine:3.5
 
 RUN apk --no-cache add ncurses-libs
 
+WORKDIR /opt/app/
+
 EXPOSE 4000
 ENV PORT=4000 MIX_ENV=prod REPLACE_OS_VARS=true
 
 ADD ${APP}.tar.gz ./
+
+RUN adduser -S default
+RUN chown -R default .
+USER default
 
 ENTRYPOINT ["/opt/app/bin/${APP}"]

--- a/priv/Dockerfile.release
+++ b/priv/Dockerfile.release
@@ -1,15 +1,10 @@
-FROM bitwalker/alpine-erlang:6.1
+FROM alpine:3.5
 
-RUN apk update && \
-    apk --no-cache --update add libgcc libstdc++ && \
-    rm -rf /var/cache/apk/*
+RUN apk --no-cache add ncurses-libs
 
 EXPOSE 4000
-ENV PORT=4000 MIX_ENV=prod REPLACE_OS_VARS=true SHELL=/bin/sh
+ENV PORT=4000 MIX_ENV=prod REPLACE_OS_VARS=true
 
 ADD ${APP}.tar.gz ./
-RUN chown -R default ./releases
-
-USER default
 
 ENTRYPOINT ["/opt/app/bin/${APP}"]


### PR DESCRIPTION
This is just a suggestion.

The build dockerfile is from my fork of msaraiva's elixir-gcc, which has the newest versions of Alpine, Erlang and Elixir installed as well as rebar, mix and build tools.

The release dockerfile is just a plain Alpine image, since distillery builds the ERTS, so nothing is needed in the target container, except the same arch as it was built under.

IMO these dockerfiles are simpler, and they have newer versions of everything.