### PR TITLE
Support umbrella apps with default distillery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,29 @@ The path is relative to the project root, and the files must be located inside
 the root.
 
 
+#### How to configure an Umbrella app?
+
+The default build Dockerfile does not handle the installation of umbrella app
+deps, so you will need to modify it to match the structure of your project.
+
+Run `mix docker.customize` and then edit `Dockerfile.build` to copy across
+each of your umbrella's applications.
+
+```dockerfile
+COPY mix.exs mix.lock ./
+
+RUN mkdir -p apps/my_first_app/config
+COPY apps/my_first_app/mix.exs apps/my_first_app/
+COPY apps/my_first_app/config/* apps/my_first_app/config/
+
+RUN mkdir -p apps/my_second_app/config
+COPY apps/my_second_app/mix.exs apps/my_second_app/
+COPY apps/my_second_app/config/* apps/my_second_app/config/
+
+# etc.
+```
+
+
 #### How to configure a Phoenix app?
 
 To run a Phoenix app you'll need to install additional packages into the build image: run `mix docker.customize`.

--- a/lib/mix_docker.ex
+++ b/lib/mix_docker.ex
@@ -23,9 +23,8 @@ defmodule MixDocker do
   end
 
   def release(args) do
-    project = Mix.Project.get.project
-    app     = project[:app]
-    version = project[:version]
+    app     = app_name()
+    version = app_version()
 
     cid = "mix_docker-#{:rand.uniform(1000000)}"
 
@@ -77,7 +76,7 @@ defmodule MixDocker do
   end
 
   defp image_name do
-    Application.get_env(:mix_docker, :image) || to_string(Mix.Project.get.project[:app])
+    Application.get_env(:mix_docker, :image) || to_string(app_name())
   end
 
   defp image_tag(:version) do
@@ -128,7 +127,7 @@ defmodule MixDocker do
   end
 
   defp copy_dockerfile(name) do
-    app = Mix.Project.get.project[:app]
+    app = app_name()
     content = [@dockerfile_path, name]
       |> Path.join
       |> File.read!
@@ -151,5 +150,14 @@ defmodule MixDocker do
 
   defp system!(cmd, args) do
     {_, 0} = system(cmd, args)
+  end
+
+  defp app_name do
+    release_name_from_cwd = File.cwd! |> Path.basename |> String.replace("-", "_")
+    Mix.Project.get.project[:app] || release_name_from_cwd
+  end
+
+  defp app_version do
+    Mix.Project.get.project[:version] || "0.1.0"
   end
 end

--- a/priv/Dockerfile.build
+++ b/priv/Dockerfile.build
@@ -20,6 +20,8 @@ WORKDIR /opt/app
 ENV MIX_ENV=prod
 
 # Cache elixir deps
+RUN mkdir config
+COPY config/* config/
 COPY mix.exs mix.lock ./
 RUN mix do deps.get, deps.compile
 


### PR DESCRIPTION
This is a sub-optimal solution, but it will get umbrellas with the default configuration running. I'll make another PR as more robust solutions are discovered :)