### PR TITLE
Custom length {git_sha}

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ See below for a list of possible variables
 |-----------------|----------------------------------------|
 | `{mix-version}` | Current project version from `mix.exs` |
 | `{rel-version}` | Default distillery release version     |
-| `{git-sha}`     | Git commit SHA                         |
+| `{git-sha}`     | Git commit SHA (10 characters)         |
+| `{git-shaN}`    | Git commit SHA (N characters)          |
 | `{git-count}`   | Git commit count                       |
 | `{git-branch}`  | Git branch                             |
 

--- a/lib/mix_docker.ex
+++ b/lib/mix_docker.ex
@@ -79,7 +79,7 @@ defmodule MixDocker do
 
   defp make_image_tag(tag) do
     template = tag || Application.get_env(:mix_docker, :tag) || @default_tag_template
-    Regex.replace(~r/\{([a-z-]+)\}/, template, fn _, x -> tagvar(x) end)
+    Regex.replace(~r/\{([a-z0-9-]+)\}/, template, fn _, x -> tagvar(x) end)
   end
 
   defp tagvar("mix-version") do
@@ -90,9 +90,10 @@ defmodule MixDocker do
     release_version()
   end
 
-  defp tagvar("git-sha") do
+  defp tagvar("git-sha"), do: tagvar("git-sha10")
+  defp tagvar("git-sha" <> length) do
     {sha, 0} = System.cmd("git", ["rev-parse", "HEAD"])
-    String.slice(sha, 0, 10)
+    String.slice(sha, 0, String.to_integer(length))
   end
 
   defp tagvar("git-branch") do


### PR DESCRIPTION
You can customize the length of the short version of the git sha by suffixing a length.

Example: {git_sha7}

Defaults to a sha of 10 characters.

Closes #23