### PR TITLE
Explicitly call mix compile

### DIFF
--- a/priv/Dockerfile.build
+++ b/priv/Dockerfile.build
@@ -27,4 +27,5 @@ RUN mix do deps.get, deps.compile
 
 COPY . .
 
+RUN mix compile
 RUN mix release --env=prod --verbose


### PR DESCRIPTION
Without explicitly calling compile I get the following error:

```
$ mix docker.build

18:24:24.655 [debug] $ docker build -f Dockerfile.build -t dylan:build .
Sending build context to Docker daemon 65.02 kB
Step 1/10 : FROM bitwalker/alpine-erlang:6.1
 ---> 0270ab72d81a
Step 2/10 : ENV HOME /opt/app/ TERM xterm
 ---> Using cache
 ---> bd028e2e1d59
Step 3/10 : RUN echo "@edge http://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/
repositories &&     apk update &&     apk --no-cache --update add       git make g++
  elixir@edge &&     rm -rf /var/cache/apk/*
 ---> Using cache
 ---> 5570b09a30b3
Step 4/10 : RUN mix local.hex --force &&     mix local.rebar --force
 ---> Using cache
 ---> cb1d59bafaab
Step 5/10 : WORKDIR /opt/app
 ---> Using cache
 ---> dd93c715509a
Step 6/10 : ENV MIX_ENV prod
 ---> Using cache
 ---> 2e4823c22ad6
Step 7/10 : COPY mix.exs mix.lock ./
 ---> Using cache
 ---> e5b61a71a94e
Step 8/10 : RUN mix do deps.get, deps.compile
 ---> Using cache
 ---> a35373094478
Step 9/10 : COPY . .
 ---> 5530a4e008f8
Removing intermediate container 1a70f8029239
Step 10/10 : RUN mix release --env=prod --verbose
 ---> Running in 3b10f595fb05
** (Mix) Cannot execute task because the project was not yet compiled. When build_embedde
d is set to true, "MIX_ENV=prod mix compile" must be explicitly executed
The command '/bin/sh -c mix release --env=prod --verbose' returned a non-zero code: 1
** (MatchError) no match of right hand side value: {%IO.Stream{device: :standard_io, line
_or_bytes: :line, raw: false}, 1}
    lib/mix_docker.ex:153: MixDocker.system!/2
    lib/mix_docker.ex:123: MixDocker.with_dockerfile/2
    lib/mix_docker.ex:18: MixDocker.build/1
    (mix) lib/mix/task.ex:294: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:58: Mix.CLI.run_task/2
```