### PR TITLE
Move dockerimage_build and dockerimage_release from module attributes to functions

### DIFF
--- a/lib/mix_docker.ex
+++ b/lib/mix_docker.ex
@@ -2,9 +2,6 @@ defmodule MixDocker do
   require Logger
 
   @dockerfile_path    :code.priv_dir(:mix_docker)
-  @dockerfile_build   Application.get_env(:mix_docker, :dockerfile_build, "Dockerfile.build")
-  @dockerfile_release Application.get_env(:mix_docker, :dockerfile_release, "Dockerfile.release")
-
   @default_tag_template "{mix-version}.{git-count}-{git-sha}"
 
   def init(args) do
@@ -17,8 +14,8 @@ defmodule MixDocker do
   end
 
   def build(args) do
-    with_dockerfile @dockerfile_build, fn ->
-      docker :build, @dockerfile_build, image(:build), args
+    with_dockerfile dockerfile_build(), fn ->
+      docker :build, dockerfile_build(), image(:build), args
     end
 
     Mix.shell.info "Docker image #{image(:build)} has been successfully created"
@@ -30,12 +27,12 @@ defmodule MixDocker do
 
     cid = "mix_docker-#{:rand.uniform(1000000)}"
 
-    with_dockerfile @dockerfile_release, fn ->
+    with_dockerfile dockerfile_release(), fn ->
       docker :rm, cid
       docker :create, cid, image(:build)
       docker :cp, cid, "/opt/app/_build/prod/rel/#{app}/releases/#{version}/#{app}.tar.gz", "#{app}.tar.gz"
       docker :rm, cid
-      docker :build, @dockerfile_release, image(:release), args
+      docker :build, dockerfile_release(), image(:release), args
     end
 
     Mix.shell.info "Docker image #{image(:release)} has been successfully created"
@@ -65,9 +62,12 @@ defmodule MixDocker do
   end
 
   def customize([]) do
-    try_copy_dockerfile @dockerfile_build
-    try_copy_dockerfile @dockerfile_release
+    try_copy_dockerfile dockerfile_build()
+    try_copy_dockerfile dockerfile_release()
   end
+
+  defp dockerfile_build, do: Application.get_env(:mix_docker, :dockerfile_build, "Dockerfile.build")
+  defp dockerfile_release, do: Application.get_env(:mix_docker, :dockerfile_release, "Dockerfile.release")
 
   defp image(tag) do
     image_name() <> ":" <> to_string(tag)


### PR DESCRIPTION
## The Problem
Currently in master, `dockerfile_build` and `dockerfile_release` are being set in module attributes.  
Module attributes are evaluted at compile time, not a runtime (see [here](https://elixir-lang.org/getting-started/module-attributes.html)).

This means that `mix_docker` will use whatever is in your application config at compile time, and any changes to your application config require you to recompile `mix_docker`.   This isn't ideal.

## The Solution
We simply move `dockerfile_build` and `dockerfile_release` to functions so they are evaluated everytime `mix docker` tasks are run.  This PR implements that solution.

## Notes
Tests are failing due to #46, but I've tested locally and it works as expected.
